### PR TITLE
Fix handling of long username/password

### DIFF
--- a/plugin.sh
+++ b/plugin.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 export PATH=$PATH:/kaniko/
 
-DOCKER_AUTH=`echo -n "${PLUGIN_USERNAME}:${PLUGIN_PASSWORD}" | base64`
+DOCKER_AUTH=`echo -n "${PLUGIN_USERNAME}:${PLUGIN_PASSWORD}" | base64 | tr -d "\n"`
 
 REGISTRY=${PLUGIN_REGISTRY:-https://index.docker.io/v1/}
 


### PR DESCRIPTION
Apparently the busybox implementation of `base64` will line-wrap long output strings.
This meant that long username+password combinations could produce base64 that
contained spurious "\n" characters, which then led to:
```
2019/05/06 00:47:39 Unable to parse "/kaniko/.docker/config.json": invalid character '\n' in string literal
```

Fixed by just removing the newlines in base64 output.  A "better" solution would use a different base64
implementation that avoided line-wrapping in the first place.